### PR TITLE
Downgrade to Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <spotless.version>2.31.0</spotless.version>
     <swagger-core-version>2.2.8</swagger-core-version>
     <threetenbp-version>1.6.5</threetenbp-version>
-    <version.java>19</version.java>
+    <version.java>17</version.java>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
as it doesn't seem to be needed and decreases the minimum requirements for users.